### PR TITLE
Bugfix buttons activation

### DIFF
--- a/GameStart/select_starter.py
+++ b/GameStart/select_starter.py
@@ -4,14 +4,22 @@ from utilities.generic_scene import GenericScene
 from utilities.player_info import Player
 import combat.emotions
 class SelectStarterScene(GenericScene):
+
+    def __init__(self, display: pygame.Surface, game_state_object, player_info = None) -> None:
+        """Initializes the object with a PyGame surface to render and data from the game session"""
+        self.display = display
+        self.game_state_object = game_state_object
+        self.player_info = player_info
+
+        start_img = pygame.image.load("start/start_button.png").convert_alpha()
+        self.starter_button = Button(self.display, 500, 500, start_img, 0.4)
+
     def game_body_loop(self):
         self.display.fill("green")
-        # add a button
-        start_img = pygame.image.load("start/start_button.png").convert_alpha()
-        starter_button = Button(self.display, 500, 500, start_img, 0.4)
-        starter_button.draw()
+
+        self.starter_button.draw()
 
         # change game state on click
-        if starter_button.clicked:
+        if self.starter_button.activated:
             self.player_info.add_emotion(combat.emotions.happiness)
             self.game_state_object.current_state = "combat"

--- a/GameStart/select_starter.py
+++ b/GameStart/select_starter.py
@@ -5,12 +5,7 @@ from utilities.player_info import Player
 import combat.emotions
 class SelectStarterScene(GenericScene):
 
-    def __init__(self, display: pygame.Surface, game_state_object, player_info = None) -> None:
-        """Initializes the object with a PyGame surface to render and data from the game session"""
-        self.display = display
-        self.game_state_object = game_state_object
-        self.player_info = player_info
-
+    def create_components(self):
         start_img = pygame.image.load("start/start_button.png").convert_alpha()
         self.starter_button = Button(self.display, 500, 500, start_img, 0.4)
 

--- a/start/button.py
+++ b/start/button.py
@@ -10,9 +10,10 @@ class Button():
         self.rect = self.image.get_rect()
         self.rect.topleft = (x, y)
         self.clicked = False
+        self.activated = False
 
     def draw(self):
-        self.clicked = False
+        self.activated = False
 
         # get mouse pos
         pos = pygame.mouse.get_pos()
@@ -21,6 +22,12 @@ class Button():
         if self.rect.collidepoint(pos):
             if pygame.mouse.get_pressed()[0] and self.clicked == False:
                 self.clicked = True
+            # button is only activated when mouse is released on top of button after left clicking
+            if self.clicked and not pygame.mouse.get_pressed()[0]:
+                self.activated = True
+                self.clicked = False
+        else:
+            self.clicked = False
 
         self.screen.blit(self.image, (self.rect.x, self.rect.y))
 

--- a/start/start_scene.py
+++ b/start/start_scene.py
@@ -4,14 +4,9 @@ import pygame
 from start.button import Button
 from utilities.generic_scene import GenericScene
 
-class StartScene(GenericScene):
+class StartScene(GenericScene):    
 
-    def __init__(self, display: pygame.Surface, game_state_object, player_info = None) -> None:
-        """Initializes the object with a PyGame surface to render and data from the game session"""
-        self.display = display
-        self.game_state_object = game_state_object
-        self.player_info = player_info
-
+    def create_components(self):
         start_img = pygame.image.load("start/start_button.png").convert_alpha()
         self.start_button = Button(self.display, 100, 100, start_img, 0.4)
 

--- a/start/start_scene.py
+++ b/start/start_scene.py
@@ -6,14 +6,21 @@ from utilities.generic_scene import GenericScene
 
 class StartScene(GenericScene):
 
+    def __init__(self, display: pygame.Surface, game_state_object, player_info = None) -> None:
+        """Initializes the object with a PyGame surface to render and data from the game session"""
+        self.display = display
+        self.game_state_object = game_state_object
+        self.player_info = player_info
+
+        start_img = pygame.image.load("start/start_button.png").convert_alpha()
+        self.start_button = Button(self.display, 100, 100, start_img, 0.4)
+
     def game_body_loop(self):
         
         self.display.fill("red")
         # add a button
-        start_img = pygame.image.load("start/start_button.png").convert_alpha()
-        start_button = Button(self.display, 100, 100, start_img, 0.4)
-        start_button.draw()
+        self.start_button.draw()
 
         # change game state on click
-        if start_button.clicked:
+        if self.start_button.activated:
             self.game_state_object.current_state = "select_starter"

--- a/utilities/generic_scene.py
+++ b/utilities/generic_scene.py
@@ -13,5 +13,12 @@ class GenericScene:
         self.game_state_object = game_state_object
         self.player_info = player_info
 
+        self.create_components()
+
+    def create_components(self) -> None:
+        """A method called during instantiation to create components like buttons. Is called once in __init__"""
+        pass
+
     def game_body_loop(self) -> None:
+        """Gets called once every main game loop"""
         pass


### PR DESCRIPTION
Issue #14 

## Why bug existed
This bug was caused in two places: The Button class and Scene classes
- Inside Button, the logic only checked if left click was being held over a button. There was no check to raise left click.
- Inside Scene classes Button creation occurred inside game_body_loop() which meant that a new Button was created every time.


## Changes
The Button class had its logic changed to only be "activated" after releasing a left click on top of the button. In the scene classes that implement Button, I changed the check from "clicked" to "activated".

For scene classes that use Button, I moved the instantiation to be outside the game loop and made Button a class variable. To help with this, I created a new method inside GenericScene which is called on instantiation. This would make it so that overriding \_\_init__ isn't necessary.